### PR TITLE
Fix: create links endpoints.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,9 @@ gem 'hanami-model', '~> 0.7'
 # Pg is the Ruby interface to the {PostgreSQL RDBMS}[http://www.postgresql.org/]
 gem 'pg'
 
+# A common interface to multiple JSON libraries.
+gem 'multi_json'
+
 group :development do
   # Code reloading
   # See: http://hanamirb.org/guides/projects/code-reloading

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,7 @@ GEM
       builder
       minitest (>= 5.0)
       ruby-progressbar
+    multi_json (1.12.1)
     nokogiri (1.7.0)
       mini_portile2 (~> 2.1.0)
     parser (2.3.1.4)
@@ -187,6 +188,7 @@ DEPENDENCIES
   hanami-model (~> 0.7)
   minitest
   minitest-reporters
+  multi_json
   pg
   pry
   pry-rescue

--- a/apps/web/application.rb
+++ b/apps/web/application.rb
@@ -5,6 +5,7 @@ require 'hanami/assets'
 require 'rack/auth/basic'
 
 module Web
+  # main file to configure the web application
   class Application < Hanami::Application
     configure do
       ##
@@ -20,10 +21,7 @@ module Web
       # code.
       # When you add new directories, remember to add them here.
       #
-      load_paths << %w(
-        controllers
-        views
-      )
+      load_paths << %w(controllers views)
 
       # Handle exceptions with HTTP statuses (true) or don't catch them (false).
       # Defaults to true.
@@ -63,12 +61,16 @@ module Web
       #           A Hash with options
       #
       # Options: :domain   - The domain (String - nil by default, not required)
-      #          :path     - Restrict cookies to a relative URI (String - nil by default)
-      #          :max_age  - Cookies expiration expressed in seconds (Integer - nil by default)
+      #          :path     - Restrict cookies to a relative URI (String - nil
+      #                      by default)
+      #          :max_age  - Cookies expiration expressed in seconds (Integer -
+      #                      nil by default)
       #          :secure   - Restrict cookies to secure connections
-      #                      (Boolean - Automatically set on true if currently using a secure connection)
+      #                      (Boolean - Automatically set on true if currently
+      #                      using a secure connection)
       #                      See #scheme and #ssl?
-      #          :httponly - Prevent JavaScript access (Boolean - true by default)
+      #          :httponly - Prevent JavaScript access (Boolean - true by
+      #                      default)
       #
       # cookies true
       # or
@@ -106,7 +108,7 @@ module Web
       # `:json` is supported)
       #           Object, the parser
       #
-      # body_parsers :json
+      body_parsers :json
 
       # When it's true and the router receives a non-encrypted request (http),
       # it redirects to the secure equivalent resource (https). Default
@@ -158,10 +160,7 @@ module Web
         stylesheet_compressor :builtin
 
         # Specify sources for assets
-        #
-        sources << [
-          'assets'
-        ]
+        sources << ['assets']
       end
 
       ##
@@ -212,8 +211,8 @@ module Web
       # Web applications can send this header to mitigate Cross Site Scripting
       # (XSS) attacks.
       #
-      # The default value allows images, scripts, AJAX, fonts and CSS from the same
-      # origin, and does not allow any other resources to load (eg object,
+      # The default value allows images, scripts, AJAX, fonts and CSS from the
+      # same origin, and does not allow any other resources to load (eg object,
       # frame, media, etc).
       #
       # Inline JavaScript is NOT allowed. To enable it, please use:
@@ -264,10 +263,10 @@ module Web
       # This is useful for sharing common functionality
       #
       # See: http://www.rubydoc.info/gems/hanami-controller#Configuration
-      controller.prepare do
-        # include MyAuthentication # included in all the actions
-        # before :authenticate!    # run an authentication before callback
-      end
+      # controller.prepare do
+      #   include MyAuthentication # included in all the actions
+      #   before :authenticate!    # run an authentication before callback
+      # end
 
       # Configure the code that will yield each time Web::View is included
       # This is useful for sharing common functionality

--- a/apps/web/application.rb
+++ b/apps/web/application.rb
@@ -114,7 +114,7 @@ module Web
       # it redirects to the secure equivalent resource (https). Default
       # disabled.
       #
-      force_ssl true
+      force_ssl true if ENV['HANAMI_ENV'] == 'production'
 
       ##
       # TEMPLATES

--- a/apps/web/controllers/links/create.rb
+++ b/apps/web/controllers/links/create.rb
@@ -5,6 +5,7 @@ module Web
       # POST '/links' endpoint action
       class Create
         include Web::Action
+        accept :json
 
         def call(params)
           link = LinkRepository.new.create(params[:link])

--- a/apps/web/controllers/links/create.rb
+++ b/apps/web/controllers/links/create.rb
@@ -7,12 +7,6 @@ module Web
         include Web::Action
         accept :json
 
-        params do
-          required(:link).schema do
-            required(:url).filled
-          end
-        end
-
         def call(params)
           link = LinkRepository.new.create(params[:link])
           self.status = 201

--- a/apps/web/controllers/links/create.rb
+++ b/apps/web/controllers/links/create.rb
@@ -16,7 +16,16 @@ module Web
         def call(params)
           link = LinkRepository.new.create(params[:link])
           self.status = 201
-          self.body   = JSON.generate(link: link.to_h)
+          self.body   = MultiJson.dump(link: link.to_h)
+        rescue Hanami::Model::Error => error
+          handle_validation_error(error)
+        end
+
+        private
+
+        def handle_validation_error(exception)
+          self.status = 422
+          self.body = MultiJson.dump(error: { message: exception.message })
         end
       end
     end

--- a/apps/web/controllers/links/create.rb
+++ b/apps/web/controllers/links/create.rb
@@ -7,6 +7,12 @@ module Web
         include Web::Action
         accept :json
 
+        params do
+          required(:link).schema do
+            required(:url).filled
+          end
+        end
+
         def call(params)
           link = LinkRepository.new.create(params[:link])
           self.status = 201

--- a/db/migrations/20161230235300_add_index_to_links.rb
+++ b/db/migrations/20161230235300_add_index_to_links.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+Hanami::Model.migration do
+  change do
+    add_index :links, :url, unique: true
+  end
+end

--- a/spec/web/requests/links_spec.rb
+++ b/spec/web/requests/links_spec.rb
@@ -27,7 +27,6 @@ class LinksAPITests < Minitest::Test
 
   def common_request_preparation
     basic_authorize ENV['HTTP_USERNAME'], ENV['HTTP_PASSWORD']
-    env 'HTTPS', 'on'
   end
 
   module POSTLinksTests
@@ -54,7 +53,6 @@ class LinksAPITests < Minitest::Test
     end
 
     def test_unauthenticated_request_to_save_link
-      env 'HTTPS', 'on'
       response = post '/links', link: sample_link
 
       assert_equal response.status, 401


### PR DESCRIPTION
Changes:
-------

- Handle model errors and return a 422 response.

- Only force ssl on **production**.

- Add SQL unique index to `Link#url`.
  This is the way to implement the _uniqueness validation_ according to:

  - https://github.com/hanami/validations#uniqueness-validation
  - https://robots.thoughtbot.com/the-perils-of-uniqueness-validations

- Add `multi_json` gem and allow the `json` `body_parsers`.
  In order to accept body parameters comming from json request, I need to enable

  ```ruby
  body_parsers :json
  ```

  And also add the `accept :json` in the Action.

  All this according:
  http://hanamirb.org/guides/actions/parameters/#body-parsers